### PR TITLE
fix: supply empty match case for geolyzer getTileEntity

### DIFF
--- a/src/main/scala/li/cil/oc/integration/gregtech/EventHandlerGregTech.scala
+++ b/src/main/scala/li/cil/oc/integration/gregtech/EventHandlerGregTech.scala
@@ -17,6 +17,7 @@ object EventHandlerGregTech {
       case tile : IGregTechTileEntity =>
         e.data += "facing" -> ForgeDirection.getOrientation(tile.getFrontFacing).name()
         e.data += "sensorInformation" -> tile.getInfoData()
+      case _ =>
     }
   }
 


### PR DESCRIPTION
No default match case was supplied for `world.getTileEntity`, which caused it raise a `MatchError` exception when analyzing something that is not `IGregTechTileEntity` resulting in `geolyzer.analyze` returning gibberish.

Stack trace of exception:
```
[18:40:50] [Server thread/ERROR]: Exception caught during firing event li.cil.oc.api.event.GeolyzerEvent$Analyze@41883bd6:
scala.MatchError: ic2.core.crop.TileEntityCrop@3404f74e (of class ic2.core.crop.TileEntityCrop)
        at li.cil.oc.integration.gregtech.EventHandlerGregTech$.onGeolyzerAnalyze(EventHandlerGregTech.scala:16) ~[EventHandlerGregTech$.class:?]
        at cpw.mods.fml.common.eventhandler.ASMEventHandler_952_EventHandlerGregTech$_onGeolyzerAnalyze_Analyze.invoke(.dynamic) ~[?:?]
        at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
        at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) [EventBus.class:?]
        at li.cil.oc.server.component.Geolyzer.analyze(Geolyzer.scala:154) [Geolyzer.class:?]
        at generated.li.cil.oc.CallWrapper_li_cil_oc_server_component_Geolyzer_analyze.call(Unknown Source) [?:?]
        at li.cil.oc.server.machine.Callbacks$ComponentCallback.apply(Callbacks.scala:123) [Callbacks$ComponentCallback.class:?]
        at li.cil.oc.server.network.Component$class.invoke(Component.scala:113) [Component$class.class:?]
        at li.cil.oc.server.network.Network$ComponentConnectorBuilder$$anon$1.invoke(Network.scala:657) [Network$ComponentConnectorBuilder$$anon$1.class:?]
        at li.cil.oc.server.machine.Machine.invoke(Machine.scala:378) [Machine.class:?]
        at li.cil.oc.server.machine.luac.ComponentAPI$$anonfun$initialize$5$$anonfun$apply$6.apply(ComponentAPI.scala:78) [ComponentAPI$$anonfun$initialize$5$$anonfun$apply$6.class:?]
        at li.cil.oc.server.machine.luac.ComponentAPI$$anonfun$initialize$5$$anonfun$apply$6.apply(ComponentAPI.scala:78) [ComponentAPI$$anonfun$initialize$5$$anonfun$apply$6.class:?]
        at li.cil.oc.server.machine.luac.NativeLuaArchitecture.invoke(NativeLuaArchitecture.scala:55) [NativeLuaArchitecture.class:?]
        at li.cil.oc.server.machine.luac.ComponentAPI$$anonfun$initialize$5.apply(ComponentAPI.scala:78) [ComponentAPI$$anonfun$initialize$5.class:?]
        at li.cil.oc.server.machine.luac.ComponentAPI$$anonfun$initialize$5.apply(ComponentAPI.scala:74) [ComponentAPI$$anonfun$initialize$5.class:?]
        at li.cil.oc.util.ExtendedLuaState$ExtendedLuaState$$anon$1.invoke(ExtendedLuaState.scala:24) [ExtendedLuaState$ExtendedLuaState$$anon$1.class:?]
        at li.cil.repack.com.naef.jnlua.LuaStateFiveThree.lua_pcall(Native Method) [LuaStateFiveThree.class:?]
        at li.cil.repack.com.naef.jnlua.LuaState.call(LuaState.java:681) [LuaState.class:?]
        at li.cil.oc.server.machine.luac.NativeLuaArchitecture.runSynchronized(NativeLuaArchitecture.scala:177) [NativeLuaArchitecture.class:?]
        at li.cil.oc.server.machine.Machine.update(Machine.scala:585) [Machine.class:?]
        at li.cil.oc.common.EventHandler$$anonfun$onServerTick$2.apply(EventHandler.scala:162) [EventHandler$$anonfun$onServerTick$2.class:?]
        at li.cil.oc.common.EventHandler$$anonfun$onServerTick$2.apply(EventHandler.scala:160) [EventHandler$$anonfun$onServerTick$2.class:?]
        at scala.collection.mutable.HashSet.foreach(HashSet.scala:78) [scala-library-2.11.1.jar:?]
        at li.cil.oc.common.EventHandler$.onServerTick(EventHandler.scala:160) [EventHandler$.class:?]
        at cpw.mods.fml.common.eventhandler.ASMEventHandler_963_EventHandler$_onServerTick_ServerTickEvent.invoke(.dynamic) [?:?]
        at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) [ASMEventHandler.class:?]
        at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) [EventBus.class:?]
        at cpw.mods.fml.common.FMLCommonHandler.onPreServerTick(FMLCommonHandler.java:260) [FMLCommonHandler.class:?]
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:536) [MinecraftServer.class:?]
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427) [MinecraftServer.class:?]
        at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [li.class:?]
```