### PR TITLE
Fix error message

### DIFF
--- a/src/main/scala/li/cil/oc/Localization.scala
+++ b/src/main/scala/li/cil/oc/Localization.scala
@@ -89,6 +89,8 @@ object Localization {
 
     def WarningFingerprint(event: FMLFingerprintViolationEvent) = new ChatComponentText("§aOpenComputers§f: ").appendSibling(localizeLater("gui.Chat.WarningFingerprint", event.expectedFingerprint, event.fingerprints.toArray.mkString(", ")))
 
+    def WarningRecipes = new ChatComponentText("§aOpenComputers§f: ").appendSibling(localizeLater("gui.Chat.WarningRecipes"))
+
     def WarningClassTransformer = new ChatComponentText("§aOpenComputers§f: ").appendSibling(localizeLater("gui.Chat.WarningClassTransformer"))
 
     def WarningSimpleComponent = new ChatComponentText("§aOpenComputers§f: ").appendSibling(localizeLater("gui.Chat.WarningSimpleComponent"))

--- a/src/main/scala/li/cil/oc/Localization.scala
+++ b/src/main/scala/li/cil/oc/Localization.scala
@@ -89,8 +89,6 @@ object Localization {
 
     def WarningFingerprint(event: FMLFingerprintViolationEvent) = new ChatComponentText("§aOpenComputers§f: ").appendSibling(localizeLater("gui.Chat.WarningFingerprint", event.expectedFingerprint, event.fingerprints.toArray.mkString(", ")))
 
-    def WarningRecipes = new ChatComponentText("§aOpenComputers§f: ").appendSibling(localizeLater("gui.Chat.WarningRecipes"))
-
     def WarningClassTransformer = new ChatComponentText("§aOpenComputers§f: ").appendSibling(localizeLater("gui.Chat.WarningClassTransformer"))
 
     def WarningSimpleComponent = new ChatComponentText("§aOpenComputers§f: ").appendSibling(localizeLater("gui.Chat.WarningSimpleComponent"))

--- a/src/main/scala/li/cil/oc/common/EventHandler.scala
+++ b/src/main/scala/li/cil/oc/common/EventHandler.scala
@@ -196,9 +196,6 @@ object EventHandler {
         if (!LuaStateFactory.isAvailable && !LuaStateFactory.luajRequested) {
           player.addChatMessage(Localization.Chat.WarningLuaFallback)
         }
-        if (Recipes.hadErrors) {
-          player.addChatMessage(Localization.Chat.WarningRecipes)
-        }
         if (ClassTransformer.hadErrors) {
           player.addChatMessage(Localization.Chat.WarningClassTransformer)
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52056774/183221615-a5b14463-fa87-47eb-a706-da9887502c8b.png)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10663

I think this was occurring because we overwrite so many recipes. Easily fixed, looks messy if we release a stable with this error.