### PR TITLE
added a way to retrieve the whole tick time table in one call

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/TpsCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/TpsCard.scala
@@ -54,6 +54,10 @@ class TpsCard (val host: EnvironmentHost) extends prefab.ManagedEnvironment with
   def getAllDims(context: Context, args: Arguments): Array[AnyRef] =
     result(DimensionManager.getWorlds.map( w => (w.provider.dimensionId, w.provider.getDimensionName())).toMap)
 
+  @Callback(doc = """function():table -- Returns a table with index corresponding to the dimension id and value at the index being the tick time taken by the dim.""")
+  def getAllTickTimes(context: Context, args: Arguments): Array[AnyRef] =
+    result(DimensionManager.getWorlds.map( w => (w.provider.dimensionId, getTickTimeSum(CoFHCore.server.worldTickTimes.get(w.provider.dimensionId)) * 1.0E-6D)).toMap)
+
   @Callback(doc = """function(dimension:number):string -- Returns the name corresponding to the dimension.""")
   def getNameForDim(context: Context, args: Arguments): Array[AnyRef] = {
     val dim = args.checkInteger(0)


### PR DESCRIPTION
Allows the users to retrieve the tick time of each dimension in one call, as building the table manually can take several seconds (tried on Delta where there are 90 dims).

Looks like it works in dev, even if the end's tick time has no key:
![image](https://user-images.githubusercontent.com/12850933/196549036-703b712a-9243-497c-9222-ff4d27bfd480.png)
i have no clue on how to fix this tho
