### PR TITLE
Add OC drivers for Essentia import/export bus

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -47,7 +47,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:BloodMagic:1.3.6:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.3.16-GTNH:dev") {
+    compileOnly("com.github.GTNewHorizons:ThaumicEnergistics:1.3.27-GTNH:dev") {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:ExtraCells2:2.5.8:dev") {

--- a/src/main/scala/li/cil/oc/integration/thaumicenergistics/DriverEssentiaExportBus.scala
+++ b/src/main/scala/li/cil/oc/integration/thaumicenergistics/DriverEssentiaExportBus.scala
@@ -1,0 +1,77 @@
+package li.cil.oc.integration.thaumicenergistics
+
+import appeng.api.parts.IPartHost
+import li.cil.oc.api.driver
+import li.cil.oc.api.driver.EnvironmentProvider
+import li.cil.oc.api.driver.NamedBlock
+import li.cil.oc.api.machine.Arguments
+import li.cil.oc.api.machine.Callback
+import li.cil.oc.api.machine.Context
+import li.cil.oc.integration.ManagedTileEntityEnvironment
+import li.cil.oc.util.ExtendedArguments._
+import li.cil.oc.util.ResultWrapper._
+import net.minecraft.item.ItemStack
+import net.minecraft.world.World
+import net.minecraftforge.common.util.ForgeDirection
+import thaumicenergistics.api.ThEApi
+import thaumicenergistics.common.parts.PartEssentiaExportBus
+
+object DriverEssentiaExportBus extends driver.SidedBlock {
+  override def worksWith(world: World, x: Int, y: Int, z: Int, side: ForgeDirection) =
+    world.getTileEntity(x, y, z) match {
+      case container: IPartHost => ForgeDirection.VALID_DIRECTIONS.map(container.getPart).filter(obj => { obj != null }).exists(_.isInstanceOf[PartEssentiaExportBus])
+      case _ => false
+    }
+
+  override def createEnvironment(world: World, x: Int, y: Int, z: Int, side: ForgeDirection) = new Environment(world, world.getTileEntity(x, y, z).asInstanceOf[IPartHost])
+
+  final class Environment(val world: World, val host: IPartHost) extends ManagedTileEntityEnvironment[IPartHost](host, "essentia_exportbus") with NamedBlock with PartEnvironmentBase {
+    override def preferredName = "essentia_exportbus"
+
+    override def priority = 2
+
+    @Callback(doc = "function(side:number[, slot:number]):string -- Get the configuration of the export bus pointing in the specified direction.")
+    def getExportConfiguration(context: Context, args: Arguments): Array[AnyRef] = getPartConfig[PartEssentiaExportBus](context, args)
+
+    @Callback(doc = "function(side:number[, slot:number][, aspect:string]):boolean -- Configure the export bus pointing in the specified direction to export essentia matching the specified type.")
+    def setExportConfiguration(context: Context, args: Arguments): Array[AnyRef] = setPartConfig[PartEssentiaExportBus](context, args)
+
+    @Callback(doc = "function(side:number):number -- Get the number of valid slots in this export bus.")
+    def getExportSlotSize(context: Context, args: Arguments): Array[AnyRef] = getSlotSize[PartEssentiaExportBus](context, args)
+
+    @Callback(doc = "function(side:number):boolean -- Get whether or not essentia exported into a void jar will allow voiding")
+    def getVoidAllowed(context: Context, args: Arguments): Array[AnyRef] = {
+      val side = args.checkSideAny(0)
+      host.getPart(side) match {
+        case part: PartEssentiaExportBus =>
+          result(part.isVoidAllowed)
+        case _ => result(Unit, "no essentia export bus")
+      }
+    }
+
+    @Callback(doc = "function(side:number, allowed:boolean):boolean -- Set void mode")
+    def setVoidAllowed(context: Context, args: Arguments): Array[AnyRef] = {
+      val side = args.checkSideAny(0)
+      val mode = args.checkBoolean(1)
+      host.getPart(side) match {
+        case part: PartEssentiaExportBus =>
+          var didSomething = false
+          if (mode != part.isVoidAllowed) {
+            part.toggleVoidMode()
+            didSomething = true
+          }
+
+          result(didSomething)
+        case _ => result(Unit, "no essentia export bus")
+      }
+    }
+
+  }
+
+  object Provider extends EnvironmentProvider {
+    override def getEnvironment(stack: ItemStack): Class[_] =
+      if (ThEApi.instance.parts.Essentia_ExportBus.getStack.isItemEqual(stack))
+        classOf[Environment]
+      else null
+  }
+}

--- a/src/main/scala/li/cil/oc/integration/thaumicenergistics/DriverEssentiaImportBus.scala
+++ b/src/main/scala/li/cil/oc/integration/thaumicenergistics/DriverEssentiaImportBus.scala
@@ -1,0 +1,45 @@
+package li.cil.oc.integration.thaumicenergistics
+
+import appeng.api.parts.IPartHost
+import li.cil.oc.api.driver
+import li.cil.oc.api.driver.{EnvironmentProvider, NamedBlock}
+import li.cil.oc.api.machine.{Arguments, Callback, Context}
+import li.cil.oc.integration.ManagedTileEntityEnvironment
+import net.minecraft.item.ItemStack
+import net.minecraft.world.World
+import net.minecraftforge.common.util.ForgeDirection
+import thaumicenergistics.api.ThEApi
+import thaumicenergistics.common.parts.PartEssentiaImportBus
+
+object DriverEssentiaImportBus extends driver.SidedBlock {
+  override def worksWith(world: World, x: Int, y: Int, z: Int, side: ForgeDirection) =
+    world.getTileEntity(x, y, z) match {
+      case container: IPartHost => ForgeDirection.VALID_DIRECTIONS.map(container.getPart).filter(obj => { obj != null }).exists(_.isInstanceOf[PartEssentiaImportBus])
+      case _ => false
+    }
+
+  override def createEnvironment(world: World, x: Int, y: Int, z: Int, side: ForgeDirection) = new Environment(world, world.getTileEntity(x, y, z).asInstanceOf[IPartHost])
+
+  final class Environment(val world: World, val host: IPartHost) extends ManagedTileEntityEnvironment[IPartHost](host, "essentia_importbus") with NamedBlock with PartEnvironmentBase {
+    override def preferredName = "essentia_importbus"
+
+    override def priority = 2
+
+    @Callback(doc = "function(side:number[, slot:number]):string -- Get the configuration of the import bus pointing in the specified direction.")
+    def getImportConfiguration(context: Context, args: Arguments): Array[AnyRef] = getPartConfig[PartEssentiaImportBus](context, args)
+
+    @Callback(doc = "function(side:number[, slot:number][, aspect:string]):boolean -- Configure the import bus pointing in the specified direction to import essentia matching the specified type.")
+    def setImportConfiguration(context: Context, args: Arguments): Array[AnyRef] = setPartConfig[PartEssentiaImportBus](context, args)
+
+    @Callback(doc = "function(side:number):number -- Get the number of valid slots in this import bus.")
+    def getImportSlotSize(context: Context, args: Arguments): Array[AnyRef] = getSlotSize[PartEssentiaImportBus](context, args)
+
+  }
+
+  object Provider extends EnvironmentProvider {
+    override def getEnvironment(stack: ItemStack): Class[_] =
+      if (ThEApi.instance.parts.Essentia_ImportBus.getStack.isItemEqual(stack))
+        classOf[Environment]
+      else null
+  }
+}

--- a/src/main/scala/li/cil/oc/integration/thaumicenergistics/ModThaumicEnergistics.scala
+++ b/src/main/scala/li/cil/oc/integration/thaumicenergistics/ModThaumicEnergistics.scala
@@ -11,9 +11,13 @@ object ModThaumicEnergistics extends ModProxy {
   override def initialize(): Unit = {
     Driver.add(DriverController)
     Driver.add(DriverBlockInterface)
+    Driver.add(DriverEssentiaExportBus)
+    Driver.add(DriverEssentiaImportBus)
 
     Driver.add(DriverController.Provider)
     Driver.add(DriverBlockInterface.Provider)
+    Driver.add(DriverEssentiaExportBus.Provider)
+    Driver.add(DriverEssentiaImportBus.Provider)
     Driver.add(ConvertAspectCraftable)
   }
 }

--- a/src/main/scala/li/cil/oc/integration/thaumicenergistics/PartEnvironmentBase.scala
+++ b/src/main/scala/li/cil/oc/integration/thaumicenergistics/PartEnvironmentBase.scala
@@ -1,0 +1,78 @@
+package li.cil.oc.integration.thaumicenergistics
+
+import appeng.api.parts.IPartHost
+import li.cil.oc.Settings
+import li.cil.oc.api.machine.{Arguments, Context}
+import li.cil.oc.api.network.ManagedEnvironment
+import li.cil.oc.util.ExtendedArguments._
+import li.cil.oc.util.ResultWrapper.result
+import net.minecraftforge.common.util.FakePlayerFactory
+import net.minecraft.world.World
+import net.minecraft.world.WorldServer
+import thaumcraft.api.aspects.Aspect
+import thaumicenergistics.common.network.IAspectSlotPart
+
+import scala.reflect.ClassTag
+
+trait PartEnvironmentBase extends ManagedEnvironment {
+  def world: World
+  def host: IPartHost
+
+  private def resolveAspectSlot(part: IAspectSlotPart, slot: Int): Int = {
+    val available = part.getAvailableAspectSlots
+
+    if (slot < 1 || slot > available.length) {
+      throw new IllegalArgumentException("invalid slot")
+    }
+    available(slot - 1)
+  }
+
+  // function(side:number):number
+  def getSlotSize[PartType <: IAspectSlotPart : ClassTag](context: Context, args: Arguments): Array[AnyRef] = {
+    val side = args.checkSideAny(0)
+    host.getPart(side) match {
+      case part: PartType =>
+        result(part.getAvailableAspectSlots.length)
+      case _ => result(Unit, "no matching part")
+    }
+  }
+
+  // function(side:number[, slot:number]):string
+  def getPartConfig[PartType <: IAspectSlotPart : ClassTag](context: Context, args: Arguments): Array[AnyRef] = {
+    val side = args.checkSideAny(0)
+    host.getPart(side) match {
+      case part: PartType =>
+        val slot = resolveAspectSlot(part, args.optInteger(1, 1))
+        val stack = Option(part.getAspect(slot))
+        result(stack match {
+          case Some(aspect) => aspect.getTag
+          case None => Unit
+        })
+      case _ => result(Unit, "no matching part")
+    }
+  }
+
+  // function(side:number[, slot:number][, aspect:string]):boolean
+  def setPartConfig[PartType <: IAspectSlotPart : ClassTag](context: Context, args: Arguments): Array[AnyRef] = {
+    val side = args.checkSideAny(0)
+    host.getPart(side) match {
+      case part: PartType =>
+        val noSlotArg = args.isString(1)
+        val slot = resolveAspectSlot(part, if (noSlotArg) 1 else args.optInteger(1, 1))
+        val aspect = if (noSlotArg || args.count > 2) {
+          Aspect.getAspect(args.checkString(if (noSlotArg) 1 else 2)) match {
+            case aspect: Aspect => aspect
+            case _ => throw new IllegalArgumentException("invalid aspect")
+          }
+        }
+        else null
+
+        val fakePlayer = FakePlayerFactory.get(world.asInstanceOf[WorldServer], Settings.get.fakePlayerProfile)
+
+        part.setAspect(slot, aspect, fakePlayer)
+        context.pause(0.5)
+        result(true)
+      case _ => result(Unit, "no matching part")
+    }
+  }
+}


### PR DESCRIPTION
Both allow getting/setting filtered aspects (using the lowercased aspect name, or `nil` to remove the filter). A convenience method was provided as well so that OC knows how many filter slots are available to set. For the essentia export bus, OC can additionally get or set the void jar voiding mode.

## Essentia Import Bus
Component name: `essentia_importbus`

`getImportConfiguration(side:number[, slot:number]):string` -- Gets configuration of the essentia import bus pointing in the specified direction.
- `side` should be one of the `sides` constants (e.g. `sides.north`) and will return `nil` alongside a descriptive error message if there is no essentia import bus on that side.
- `slot` should be a valid slot number (based on number of capacity cards: 1 with no cards, 1-5 with 1 card, and 1-9 with 2 cards). An error is raised on an invalid slot number. If `slot` is omitted, returns the configuration for the first slot.
- Returns the essentia name the slot is configured for as a lowercased string, or `nil` if no essentia type is configured for that slot.

`setImportConfiguration(side:number[, slot:number][, aspect:string]):boolean` -- Sets or unsets the configuration of the essentia import bus pointing in the specified direction.
- `side` should be one of the `sides` constants (e.g. `sides.north`) and will return `nil` alongside a descriptive error message if there is no essentia import bus on that side.
- `slot` should be a valid slot number (based on number of capacity cards: 1 with no cards, 1-5 with 1 card, and 1-9 with 2 cards). An error is raised on an invalid slot number. If `slot` is omitted, sets the configuration for the first slot.
- `aspect` should be the lowercased aspect tag, or `nil` to unset the configuration for that slot. An error is raised if the specified aspect does not exist.
- Returns `true` if the configuration for that slot changed and `false` if the configuration for that slot did not change (i.e. it was already set to the specified aspect).

`getImportSlotSize(side:number):number` -- Gets the number of valid slots that may be configured in this essentia import bus.
- `side` should be one of the `sides` constants (e.g. `sides.north`) and will return `nil` alongside a descriptive error message if there is no essentia import bus on that side.
- Returns a number based on the amount of installed capacity cards: `1` for 0 cards, `5` for 1 card, and `9` for 2 cards (an essentia import bus can never have more than 2 capacity cards installed).

## Essentia Export Bus
Component name: `essentia_exportbus`

`getExportConfiguration(side:number[, slot:number]):string` -- Gets configuration of the essentia export bus pointing in the specified direction.
- `side` should be one of the `sides` constants (e.g. `sides.north`) and will return `nil` alongside a descriptive error message if there is no essentia export bus on that side.
- `slot` should be a valid slot number (based on number of capacity cards: 1 with no cards, 1-5 with 1 card, and 1-9 with 2 cards). An error is raised on an invalid slot number. If `slot` is omitted, returns the configuration for the first slot.
- Returns the essentia name the slot is configured for as a lowercased string, or `nil` if no essentia type is configured for that slot.

`setExportConfiguration(side:number[, slot:number][, aspect:string]):boolean` -- Sets or unsets the configuration of the essentia export bus pointing in the specified direction.
- `side` should be one of the `sides` constants (e.g. `sides.north`) and will return `nil` alongside a descriptive error message if there is no essentia export bus on that side.
- `slot` should be a valid slot number (based on number of capacity cards: 1 with no cards, 1-5 with 1 card, and 1-9 with 2 cards). An error is raised on an invalid slot number. If `slot` is omitted, sets the configuration for the first slot.
- `aspect` should be the lowercased aspect tag, or `nil` to unset the configuration for that slot. An error is raised if the specified aspect does not exist.
- Returns `true` if the configuration for that slot changed and `false` if the configuration for that slot did not change (i.e. it was already set to the specified aspect).

`getExportSlotSize(side:number):number` -- Gets the number of valid slots that may be configured in this essentia export bus.
- `side` should be one of the `sides` constants (e.g. `sides.north`) and will return `nil` alongside a descriptive error message if there is no essentia export bus on that side.
- Returns a number based on the amount of installed capacity cards: `1` for 0 cards, `5` for 1 card, and `9` for 2 cards (an essentia export bus can never have more than 2 capacity cards installed).

`getVoidAllowed(side:number):boolean` -- Gets the current behavior of the essentia export bus if it is configured to export into a void jar.
- `side` should be one of the `sides` constants (e.g. `sides.north`) and will return `nil` alongside a descriptive error message if there is no essentia export bus on that side.
- Returns `true` if the export bus will export into the void jar even if it is at capacity (thereby voiding any excess essentia), or `false` if it will stop exporting once the void jar is full.

`setVoidAllowed(side:number, allowed:boolean):boolean` -- Sets the behavior of the essentia export bus if it is configured to export into a void jar.
- `side` should be one of the `sides` constants (e.g. `sides.north`) and will return `nil` alongside a descriptive error message if there is no essentia export bus on that side.
- `allowed` should be `true` if excess essentia should be voided, and `false` if the export bus should stop exporting once the void jar is full.
- Returns `true` if the void jar configuration changed and `false` if it did not change (i.e. it was already set to the specified voiding behavior).

## Notes
- All of these are synchronized calls and will return on the next game tick.
- From my testing, it seems that a single adapter is not able to recognize multiple different component types in the same block (that is, if an essentia import bus shares a block with an essentia export bus). It will instead choose one or the other. If multiple of the *same* bus is in the block, it will work just fine (by using the `side` argument in each call).
- I'm open to modifications to the API as outlined above (additions, changes, or removals). I picked what I felt was a decent enough set of functionality, but there could potentially be more (such as the ability to configure every slot at once rather than one at a time).