### PR TITLE
keybinds

### DIFF
--- a/src/main/scala/li/cil/oc/client/KeyBindings.scala
+++ b/src/main/scala/li/cil/oc/client/KeyBindings.scala
@@ -42,7 +42,7 @@ object KeyBindings {
 
   def extendedTooltip = FMLClientHandler.instance.getClient.gameSettings.keyBindSneak
 
-  val materialCosts = new KeyBinding("key.materialCosts", Keyboard.KEY_LMENU, OpenComputers.Name)
+  val materialCosts = new KeyBinding("key.materialCosts", Keyboard.KEY_NONE, OpenComputers.Name)
 
-  val clipboardPaste = new KeyBinding("key.clipboardPaste", Keyboard.KEY_INSERT, OpenComputers.Name)
+  val clipboardPaste = new KeyBinding("key.clipboardPaste", Keyboard.KEY_NONE, OpenComputers.Name)
 }


### PR DESCRIPTION
The goal is to unbind all keys that are not used from the start of the game in the GTNH modpack to avoid all the current keybinds conflict and leave to the user the choice of the keybinds they want.