### PR TITLE
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12990

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,7 +13,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:EnderStorage:1.4.12:dev") {
         transitive = false
     }
-    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.277:dev")
+    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.42.58:dev")
     compile("com.github.GTNewHorizons:ForestryMC:4.5.6:dev") {
         transitive = false
     }

--- a/src/main/scala/li/cil/oc/common/EventHandler.scala
+++ b/src/main/scala/li/cil/oc/common/EventHandler.scala
@@ -138,6 +138,7 @@ object EventHandler {
   def scheduleWirelessRedstone(rs: server.component.RedstoneWireless) {
     if (SideTracker.isServer) pendingServer.synchronized {
       pendingServer += (() => if (rs.node.network != null) {
+        util.WirelessRedstone.resetRedstone(rs)
         util.WirelessRedstone.addReceiver(rs)
         util.WirelessRedstone.updateOutput(rs)
       })

--- a/src/main/scala/li/cil/oc/integration/util/WirelessRedstone.scala
+++ b/src/main/scala/li/cil/oc/integration/util/WirelessRedstone.scala
@@ -35,6 +35,11 @@ object WirelessRedstone {
 
   def getInput(rs: RedstoneWireless) = systems.exists(_.getInput(rs))
 
+  def resetRedstone(rs: RedstoneWireless): Unit =
+    systems.foreach(system => try system.resetRedstone(rs) catch {
+      case _: Throwable => // Ignore
+    })
+
   trait WirelessRedstoneSystem {
     def addReceiver(rs: RedstoneWireless)
 
@@ -45,6 +50,8 @@ object WirelessRedstone {
     def removeTransmitter(rs: RedstoneWireless)
 
     def getInput(rs: RedstoneWireless): Boolean
+
+    def resetRedstone(rs: RedstoneWireless)
   }
 
 }

--- a/src/main/scala/li/cil/oc/integration/wrcbe/WirelessRedstoneCBE.scala
+++ b/src/main/scala/li/cil/oc/integration/wrcbe/WirelessRedstoneCBE.scala
@@ -4,6 +4,7 @@ import codechicken.wirelessredstone.core.RedstoneEther
 import li.cil.oc.integration.util.WirelessRedstone.WirelessRedstoneSystem
 import li.cil.oc.server.component.RedstoneWireless
 
+import scala.collection.JavaConversions.asScalaBuffer
 import scala.language.reflectiveCalls
 
 object WirelessRedstoneCBE extends WirelessRedstoneSystem {
@@ -40,4 +41,12 @@ object WirelessRedstoneCBE extends WirelessRedstoneSystem {
   }
 
   def getInput(rs: RedstoneWireless) = rs.wirelessInput
+
+  def resetRedstone(rs: RedstoneWireless): Unit = {
+    val ff = RedstoneEther.server.getTransmittingDevicesOnFreq(rs.wirelessFrequency).filter(f => {
+      (f.getPosition() == rs.getPosition()) && (f.getDimension() == rs.getDimension)
+    }).foreach {
+      RedstoneEther.server.removeTransmittingDevice(_)
+    }
+  }
 }

--- a/src/main/scala/li/cil/oc/integration/wrsve/WirelessRedstoneSVE.scala
+++ b/src/main/scala/li/cil/oc/integration/wrsve/WirelessRedstoneSVE.scala
@@ -49,4 +49,6 @@ object WirelessRedstoneSVE extends WirelessRedstoneSystem {
   }
 
   def getInput(rs: RedstoneWireless) = ether.fold(false)(_.getFreqState(rs.redstone.world, rs.wirelessFrequency.toString))
+
+  def resetRedstone(rs: RedstoneWireless) = {}
 }


### PR DESCRIPTION
Opencomputers can break Wireless Redstone channels
(This change checks & removes possible previous instances of this redstone card in the wireless ether before registering it)