### PR TITLE
Increase MFU range from 3 to 16 blocks

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1394,7 +1394,7 @@ opencomputers {
     tradingRange: 8.0
 
     # Radius the MFU is able to operate in
-    mfuRange: 3
+    mfuRange: 16
 
     # Transposer fluid transfer rate in millibuckets per second
     # It may transfer unlimited amount per operation, but will then 


### PR DESCRIPTION
The range is quite limiting especially for very large multiblocks like most megas. Increasing it from 3 to 16 should allow neater setups by not forcing players to wire the adapter on the front face of such multis.

(The MFU is an upgrade to adapters that allow connecting a single block to the adapter wirelessly)