### PR TITLE
added setActive for IC2-OC driver, so that the reactor switch can be …

### DIFF
--- a/src/main/scala/li/cil/oc/integration/ic2/DriverReactor.java
+++ b/src/main/scala/li/cil/oc/integration/ic2/DriverReactor.java
@@ -1,6 +1,8 @@
 package li.cil.oc.integration.ic2;
 
 import ic2.api.reactor.IReactor;
+import ic2.core.block.TileEntityBlock;
+import ic2.core.block.reactor.tileentity.TileEntityNuclearReactorElectric;
 import li.cil.oc.api.driver.NamedBlock;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
@@ -36,6 +38,16 @@ public final class DriverReactor extends DriverSidedTileEntity {
         @Override
         public int priority() {
             return 0;
+        }
+
+        @Callback(doc = "function(active:boolean): boolean -- activate or deactivate the reactor")
+        public Object[] setActive(final Context context, final Arguments args) {
+            TileEntityNuclearReactorElectric reactor = (TileEntityNuclearReactorElectric) tileEntity;
+            if(reactor != null) {
+                reactor.setRedstoneSignal(args.optBoolean(0, false));
+                return new Object[]{reactor.receiveredstone()};
+            }
+            return new Object[]{false};
         }
 
         @Callback(doc = "function():number -- Get the reactor's heat.")

--- a/src/main/scala/li/cil/oc/integration/ic2/DriverReactorChamber.java
+++ b/src/main/scala/li/cil/oc/integration/ic2/DriverReactorChamber.java
@@ -2,6 +2,8 @@ package li.cil.oc.integration.ic2;
 
 import ic2.api.reactor.IReactor;
 import ic2.api.reactor.IReactorChamber;
+import ic2.core.block.TileEntityBlock;
+import ic2.core.block.reactor.tileentity.TileEntityNuclearReactorElectric;
 import li.cil.oc.api.driver.NamedBlock;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
@@ -39,6 +41,15 @@ public final class DriverReactorChamber extends DriverSidedTileEntity {
             return 0;
         }
 
+        @Callback(doc = "function(active:boolean): boolean -- activate or deactivate the reactor")
+        public Object[] setActive(final Context context, final Arguments args) {
+            TileEntityNuclearReactorElectric reactor = (TileEntityNuclearReactorElectric) tileEntity.getReactor();
+            if(reactor != null) {
+                reactor.setRedstoneSignal(args.optBoolean(0, false));
+                return new Object[]{reactor.receiveredstone()};
+            }
+            return new Object[]{false};
+        }
         @Callback(doc = "function():number -- Get the reactor's heat.")
         public Object[] getHeat(final Context context, final Arguments args) {
             final IReactor reactor = tileEntity.getReactor();

--- a/src/main/scala/li/cil/oc/integration/ic2/DriverReactorRedstonePort.java
+++ b/src/main/scala/li/cil/oc/integration/ic2/DriverReactorRedstonePort.java
@@ -2,6 +2,9 @@ package li.cil.oc.integration.ic2;
 
 import ic2.api.reactor.IReactor;
 import ic2.api.reactor.IReactorChamber;
+import ic2.core.block.TileEntityBlock;
+import ic2.core.block.reactor.tileentity.TileEntityNuclearReactorElectric;
+import ic2.core.block.reactor.tileentity.TileEntityReactorChamberElectric;
 import ic2.core.block.reactor.tileentity.TileEntityReactorRedstonePort;
 import li.cil.oc.api.driver.NamedBlock;
 import li.cil.oc.api.machine.Arguments;
@@ -50,6 +53,17 @@ public final class DriverReactorRedstonePort extends DriverSidedTileEntity {
             } else {
                 return ((IReactorChamber) reactorInventory).getReactor();
             }
+        }
+
+        @Callback(doc = "function(active:boolean): boolean -- activate or deactivate the reactor")
+        public Object[] setActive(final Context context, final Arguments args) {
+            TileEntityReactorChamberElectric reactorChamberElectric = (TileEntityReactorChamberElectric) tileEntity.getReactor();
+            TileEntityNuclearReactorElectric reactor = reactorChamberElectric.getReactor();
+            if(reactor != null) {
+                reactor.setRedstoneSignal(args.optBoolean(0, false));
+                return new Object[]{reactor.receiveredstone()};
+            }
+            return new Object[]{false};
         }
 
         @Callback(doc = "function():number -- Get the reactor's heat.")


### PR DESCRIPTION
This update can make it more convenient to build a safer reactor with OpenComputers.
![2023-09-16_22 57 11](https://github.com/GTNewHorizons/OpenComputers/assets/57739338/cb644f72-abb6-4936-bcd8-190b197bcec7)
