### PR TITLE
Adds method to get Fluid Reactor's Heat output

### DIFF
--- a/src/main/scala/li/cil/oc/integration/ic2/DriverReactorRedstonePort.java
+++ b/src/main/scala/li/cil/oc/integration/ic2/DriverReactorRedstonePort.java
@@ -111,5 +111,16 @@ public final class DriverReactorRedstonePort extends DriverSidedTileEntity {
                 return new Object[] {false};
             }
         }
+
+        @Callback(doc = "function():number -- Get the reactor's emitted heat. Useful for fluid reactors.")
+        public Object[] getEmitHeat(final Context context, final Arguments args) {
+            final IReactor reactor = getReactor();
+            if(reactor instanceof TileEntityNuclearReactorElectric) {
+                TileEntityNuclearReactorElectric fluidReactor = (TileEntityNuclearReactorElectric) reactor;
+                return new Object[] {fluidReactor.EmitHeat};
+            } else {
+                return new Object[] {};
+            }
+        }
     }
 }

--- a/src/main/scala/li/cil/oc/integration/ic2/DriverReactorRedstonePort.java
+++ b/src/main/scala/li/cil/oc/integration/ic2/DriverReactorRedstonePort.java
@@ -119,7 +119,7 @@ public final class DriverReactorRedstonePort extends DriverSidedTileEntity {
                 TileEntityNuclearReactorElectric fluidReactor = (TileEntityNuclearReactorElectric) reactor;
                 return new Object[] {fluidReactor.EmitHeat};
             } else {
-                return new Object[] {};
+                return new Object[] {0};
             }
         }
     }


### PR DESCRIPTION
There was no way to get information about how much Heat Units (HU/s) a Fluid Reactor outputs (At least I could not find a way). And looking at Nuclear Control source code, I found how that mod is doing that and I have added similar method to DriverReactorRedstonePort.
