### PR TITLE
Add missing @SideOnly marker

### DIFF
--- a/src/main/scala/li/cil/oc/client/Textures.scala
+++ b/src/main/scala/li/cil/oc/client/Textures.scala
@@ -1,5 +1,6 @@
 package li.cil.oc.client
 
+import cpw.mods.fml.relauncher.{Side, SideOnly}
 import li.cil.oc.Settings
 import net.minecraft.client.renderer.texture.TextureManager
 import net.minecraft.util.IIcon
@@ -130,6 +131,7 @@ object Textures {
     var iconOn: IIcon = _
   }
 
+  @SideOnly(Side.CLIENT)
   def init(tm: TextureManager) {
     tm.bindTexture(fontAntiAliased)
     tm.bindTexture(fontAliased)


### PR DESCRIPTION
Added a missing `@SideOnly` marker, which was causing a `ClassNotFoundException` under certain conditions.