### PR TITLE
use buffer in LuaStateFactory file comparison

### DIFF
--- a/src/main/scala/li/cil/oc/server/machine/luac/LuaStateFactory.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luac/LuaStateFactory.scala
@@ -1,5 +1,6 @@
 package li.cil.oc.server.machine.luac
 
+import java.io.BufferedInputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -242,8 +243,8 @@ abstract class LuaStateFactory {
       if (tmpLibFile.exists()) {
         var matching = true
         try {
-          val inCurrent = libraryUrl.openStream()
-          val inExisting = new FileInputStream(tmpLibFile)
+          val inCurrent = new BufferedInputStream(libraryUrl.openStream())
+          val inExisting = new BufferedInputStream(new FileInputStream(tmpLibFile))
           var inCurrentByte = 0
           var inExistingByte = 0
           do {


### PR DESCRIPTION
LuaStateFactory compares files using non-buffered, single byte reads. This PR wraps the FileInputStream in a BufferedInputStream to buffer reads.

before: `_root > Loading > PreInitialization > OpenComputers	4.757485(s) `
after: `_root > Loading > PreInitialization > OpenComputers	1.149008(s)`