### PR TITLE
fix client side memory leak on anything RedstoneAware

### DIFF
--- a/src/main/scala/li/cil/oc/common/tileentity/traits/RedstoneAware.scala
+++ b/src/main/scala/li/cil/oc/common/tileentity/traits/RedstoneAware.scala
@@ -135,7 +135,7 @@ trait RedstoneAware extends RotationAware with IConnectable with IRedstoneEmitte
 
   override def validate(): Unit = {
     super.validate()
-    if (!canUpdate) {
+    if (!canUpdate && isServer) {
       EventHandler.scheduleServer(() => ForgeDirection.VALID_DIRECTIONS.foreach(updateRedstoneInput))
     }
   }


### PR DESCRIPTION
This lambda implicitly references `this` (a TileEntity). On dedicated server it's perfectly fine. In MP, on client side the callback will never be executed. Beside the memory leak, it's pointless to do it on client side tile entity.