### PR TITLE
Remove old dependency.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,7 +14,6 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Railcraft:9.16.3:dev") {transitive = false }
     compile("com.github.GTNewHorizons:NotEnoughItems:2.7.27-GTNH:dev") {transitive = false }
     compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.2:dev") {transitive = false }
-    compile("com.github.GTNewHorizons:CodeChickenLib:1.3.0:dev") {transitive = false }
     compile("com.github.GTNewHorizons:CodeChickenCore:1.4.1:dev") {transitive = false }
     compileOnly("com.github.GTNewHorizons:waila:1.8.2:dev") {transitive = false }
     compileOnly("com.github.GTNewHorizons:Galacticraft:3.3.4-GTNH:dev") {transitive = false }


### PR DESCRIPTION
CodeChickenLib is no longer needed and breaks debugger.