### PR TITLE
Fix ME Upgrades tiers 1 and 3 being swapped

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -47,8 +47,8 @@ dependencies {
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive = false}
     compileOnly("qmunity:QmunityLib:0.1.105:deobf") {transitive = false}
     compileOnly(deobf("https://github.com/purpleposeidon/fz_archive/raw/master/old/Factorization-1.7.10-0.8.108.jar"))
-    compileOnly(deobf("https://immibis.com/mcmoddl/files/immibis-microblocks-59.1.2.jar"))
-    compileOnly(deobf("https://immibis.com/mcmoddl/files/redlogic-59.1.13.jar"))
+    compileOnly("maven.modrinth:immibis-microblocks:59.1.2")
+    compileOnly("maven.modrinth:redlogic:59.1.13")
     compileOnly(files("dependencies/ic2classic-api.zip")) // curseforge one does NOT work ...
 
     testImplementation("org.mockito:mockito-all:1.10.19")

--- a/src/main/scala/li/cil/oc/integration/appeng/UpgradeAE.scala
+++ b/src/main/scala/li/cil/oc/integration/appeng/UpgradeAE.scala
@@ -80,13 +80,29 @@ class UpgradeAE(val host: EnvironmentHost, val tier: Int) extends ManagedEnviron
     if (grid == null) return false
     stack.getItemDamage match {
       case 0 =>
-        grid
-          .getMachines(
+        val gridBlock = gridNode.getGridBlock
+        if (gridBlock == null) return false
+        val loc = gridBlock.getLocation
+        if (loc == null) return false
+        for (
+          node <- grid.getMachines(
             AEApi.instance.definitions.blocks.wireless.maybeEntity.get
               .asInstanceOf[Class[_ <: IGridHost]]
           )
-          .iterator
-          .hasNext
+        ) {
+          val accessPoint: IWirelessAccessPoint =
+            node.getMachine.asInstanceOf[IWirelessAccessPoint]
+          val distance: WorldCoord = accessPoint.getLocation.subtract(
+            agent.xPosition.toInt,
+            agent.yPosition.toInt,
+            agent.zPosition.toInt
+          )
+          val squaredDistance: Int =
+            distance.x * distance.x + distance.y * distance.y + distance.z * distance.z
+          val range = accessPoint.getRange / 2
+          if (squaredDistance <= range * range) return true
+        }
+        false
       case 1 =>
         val gridBlock = gridNode.getGridBlock
         if (gridBlock == null) return false
@@ -112,29 +128,13 @@ class UpgradeAE(val host: EnvironmentHost, val tier: Int) extends ManagedEnviron
         }
         false
       case _ =>
-        val gridBlock = gridNode.getGridBlock
-        if (gridBlock == null) return false
-        val loc = gridBlock.getLocation
-        if (loc == null) return false
-        for (
-          node <- grid.getMachines(
+        grid
+          .getMachines(
             AEApi.instance.definitions.blocks.wireless.maybeEntity.get
               .asInstanceOf[Class[_ <: IGridHost]]
           )
-        ) {
-          val accessPoint: IWirelessAccessPoint =
-            node.getMachine.asInstanceOf[IWirelessAccessPoint]
-          val distance: WorldCoord = accessPoint.getLocation.subtract(
-            agent.xPosition.toInt,
-            agent.yPosition.toInt,
-            agent.zPosition.toInt
-          )
-          val squaredDistance: Int =
-            distance.x * distance.x + distance.y * distance.y + distance.z * distance.z
-          val range = accessPoint.getRange / 2
-          if (squaredDistance <= range * range) return true
-        }
-        false
+          .iterator
+          .hasNext
     }
   }
 


### PR DESCRIPTION
Currently ME Upgrade's 1 and 3 are swapped, causing tier one to have infinite range, and [tier 3 to have limited range](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18046) .

Pull request essentially swaps "0" and "_" cases in a match statement that checks for item metadata.