### PR TITLE
compat fix when other mods are NOT installed

### DIFF
--- a/src/main/scala/li/cil/oc/integration/opencomputers/ModOpenComputers.scala
+++ b/src/main/scala/li/cil/oc/integration/opencomputers/ModOpenComputers.scala
@@ -403,8 +403,10 @@ object ModOpenComputers extends ModProxy {
   }
 
   private def blacklistHost(host: Class[_], itemNames: String*) {
-    for (itemName <- itemNames) {
-      api.IMC.blacklistHost(itemName, host, api.Items.get(itemName).createItemStack(1))
+    for (itemName <- itemNames) api.Items.get(itemName) match {
+      case null => null
+      case itemInfo: ItemInfo => api.IMC.blacklistHost(itemName, host, itemInfo.createItemStack(1))
+      case _ => null
     }
   }
 


### PR DESCRIPTION
In [integration.opencomputers.ModOpenComputers.initialize](https://github.com/GTNewHorizons/OpenComputers/blob/69612aa09fa7493be497e57c2fb067e36ea18e00/src/main/scala/li/cil/oc/integration/opencomputers/ModOpenComputers.scala#L216), blacklists are added for component items. However some items are registered by other integration code, and only exists if the corresponding mod is installed.

When such mod (specifically, AE2) is not installed, the item doesn't exist, causing error on startup.

With this change, `blacklistHost` checks that `api.Items.get` indeed succeeded, ignoring non-existent items being registered into the blacklist.