### PR TITLE
Fix stack size assignment in DatabaseAccess

### DIFF
--- a/src/main/scala/li/cil/oc/util/DatabaseAccess.scala
+++ b/src/main/scala/li/cil/oc/util/DatabaseAccess.scala
@@ -28,7 +28,7 @@ object DatabaseAccess {
       val dbStack = database.getStackInSlot(entry - 1)
       if (dbStack == null || size < 1) null
       else {
-        dbStack.stackSize = math.min(size, dbStack.getMaxStackSize)
+        dbStack.stackSize = size
         dbStack
       }
     })


### PR DESCRIPTION
Remove the restriction of pattern size of MaxStackSize.

It's possible for a recipe to request items exceeding its maximum stack size. Also MaxStackSize seems to be mistakenly set to 64 for liquid so it's impossible to construct patterns with liquid size exceeding 64mB.