### PR TITLE
fix(appeng): isolate AE2 registration to prevent NoClassDefFoundError

### DIFF
--- a/src/main/scala/li/cil/oc/integration/appeng/ModAppEng.scala
+++ b/src/main/scala/li/cil/oc/integration/appeng/ModAppEng.scala
@@ -19,10 +19,13 @@ import net.minecraft.world.World
 object ModAppEng extends ModProxy {
   override def getMod = Mods.AppliedEnergistics2
 
-  override def initialize() {
+  private lazy val lazyRegister = new {
     AEStackFactory.register[IAEFluidStack](AEFluidStackType.FLUID_STACK_TYPE, ConverterAEFluidStack.convert, ConverterAEFluidStack.parse)
     AEStackFactory.register[IAEItemStack](AEItemStackType.ITEM_STACK_TYPE, ConverterAEItemStack.convert, ConverterAEItemStack.parse)
+  }
 
+  override def initialize() {
+    lazyRegister
     api.IMC.registerWrenchTool("li.cil.oc.integration.appeng.EventHandlerAE2.useWrench")
     api.IMC.registerWrenchToolCheck("li.cil.oc.integration.appeng.EventHandlerAE2.isWrench")
 

--- a/src/main/scala/li/cil/oc/integration/thaumicenergistics/ModThaumicEnergistics.scala
+++ b/src/main/scala/li/cil/oc/integration/thaumicenergistics/ModThaumicEnergistics.scala
@@ -8,9 +8,11 @@ import thaumicenergistics.common.storage.{AEEssentiaStack, AEEssentiaStackType}
 object ModThaumicEnergistics extends ModProxy {
   override def getMod: Mod = Mods.ThaumicEnergistics
 
-  override def initialize(): Unit = {
+  private lazy val lazyRegister = new {
     AEStackFactory.register[AEEssentiaStack](AEEssentiaStackType.ESSENTIA_STACK_TYPE, ConvertAEEssentiaStack.convert, ConvertAEEssentiaStack.parse)
-
+  }
+  override def initialize(): Unit = {
+    lazyRegister
     Driver.add(DriverController)
     Driver.add(DriverBlockInterface)
     Driver.add(DriverEssentiaExportBus)


### PR DESCRIPTION
Fixes the crash when AE2 is missing, as reported [here](https://github.com/GTNewHorizons/OpenComputers/pull/169#issuecomment-4380117976).