### PR TITLE
expose computer.realTime() to user programs

### DIFF
--- a/src/main/resources/assets/opencomputers/lua/machine.lua
+++ b/src/main/resources/assets/opencomputers/lua/machine.lua
@@ -1388,6 +1388,7 @@ local libcomputer = {
   freeMemory = computer.freeMemory,
   totalMemory = computer.totalMemory,
   uptime = computer.uptime,
+  realTime = computer.realTime,
   energy = computer.energy,
   maxEnergy = computer.maxEnergy,
 


### PR DESCRIPTION
realTime was available in the native computer API but filtered out in machine.lua's libcomputer whitelist, making it inaccessible from OpenOS. Added it to libcomputer so user programs can get the real-world Unix timestamp via computer.realTime().
<img width="536" height="219" alt="image" src="https://github.com/user-attachments/assets/7f3f4a84-3ab9-4946-a189-09dfe4b866a5" />
