### PR TITLE
chore: Clarify NBT data requirement in getItemInNetwork

### DIFF
--- a/src/main/scala/li/cil/oc/integration/appeng/NetworkControl.scala
+++ b/src/main/scala/li/cil/oc/integration/appeng/NetworkControl.scala
@@ -125,7 +125,7 @@ trait NetworkControl[AETile >: Null <: TileEntity with IGridProxyable with IActi
       .toArray)
   }
 
-  @Callback(doc = "function(name:string|id:number[, damage:number[, nbt:string]]):table -- Retrieves the stored item in the network by its unlocalized name.")
+  @Callback(doc = "function(name:string|id:number[, damage:number[, nbt:string]]):table -- Retrieves the stored item in the network by its unlocalized name. NBT data needs to be a JSON string.")
   def getItemInNetwork(context: Context, args: Arguments): Array[AnyRef] = {
     val item = if (args.isString(0)) Item.itemRegistry.getObject(args.checkString(0))
     else Item.itemRegistry.getObjectById(args.checkInteger(0))


### PR DESCRIPTION
Updated documentation of getItemInNetwork to specify that NBT data needs to be a JSON string.

When I tried to program a program for this I needed to look up this method to figure out how the nbt data needs to be formatted. 
This updates the doc for the method so you can now see ingame  it  needs to be a json.