### PR TITLE
fix: batch clipboard paste signals

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -277,9 +277,9 @@ opencomputers {
     # A machine state should be pulling signals via computer.pullSignal
     # As the machine receives signals they are queued for pulling, and
     # this maximum defines the max queue size. All signals recieved when
-    # the queue is full are discarded. Note that clipboard text creates
-    # a signal for each line of text. Thus client are limited to pasting
-    # text of this many lines. The default (and minimum) is 256
+    # the queue is full are discarded. Clipboard text creates one signal per
+    # configured clipboard chunk; chunks are independent of line breaks. The
+    # default (and minimum) is 256
     maxSignalQueueSize: 256
   }
 
@@ -1257,10 +1257,10 @@ opencomputers {
     # Note: also applies to the motion sensor.
     inputUsername: true
 
-    # The maximum length of a string that may be pasted. This is used to limit
-    # the size of the data sent to the server when the user tries to paste a
-    # string from the clipboard (Shift+Ins on a screen with a keyboard).
-    maxClipboard: 1024
+    # The maximum length of each clipboard signal. Clipboard contents are
+    # split into chunks of this size, independent of line breaks, so one
+    # signal can contain multiple short lines.
+    maxClipboard: 256
 
     # The TTL (Time-To-Live) upon creation of a network packet. When a packet
     # passes through a Relay, its TTL is decremented. If a Relay receives a

--- a/src/main/scala/li/cil/oc/Settings.scala
+++ b/src/main/scala/li/cil/oc/Settings.scala
@@ -343,6 +343,7 @@ class Settings(val config: Config) {
   val maxScreenWidth = config.getInt("misc.maxScreenWidth") max 1
   val maxScreenHeight = config.getInt("misc.maxScreenHeight") max 1
   val inputUsername = config.getBoolean("misc.inputUsername")
+  val maxClipboard = config.getInt("misc.maxClipboard") max 1
   val initialNetworkPacketTTL = config.getInt("misc.initialNetworkPacketTTL") max 5
   val maxNetworkPacketSize = config.getInt("misc.maxNetworkPacketSize") max 0
   // Need at least 4 for nanomachine protocol. Because I can!
@@ -792,4 +793,3 @@ object Settings {
       default.getOrElse(new java.util.LinkedList[Integer]())
   }
 }
-

--- a/src/main/scala/li/cil/oc/client/PacketSender.scala
+++ b/src/main/scala/li/cil/oc/client/PacketSender.scala
@@ -14,6 +14,12 @@ import net.minecraft.util.ResourceLocation
 import net.minecraftforge.common.util.ForgeDirection
 
 object PacketSender {
+  // The server can queue this many clipboard chunks. Keep the client-side
+  // whole-paste limit in line with that capacity instead of imposing the
+  // unrelated historical 64 KiB limit.
+  private def maxClipboardLength: Long =
+    Settings.get.maxClipboard.toLong * Settings.get.maxSignalQueueSize
+
   // Timestamp after which the next clipboard message may be sent. Used to
   // avoid spamming large packets on key repeat.
   protected var clipboardCooldown = 0L
@@ -72,7 +78,7 @@ object PacketSender {
 
   def sendClipboard(address: String, value: String) {
     if (value != null && !value.isEmpty) {
-      if (value.length > 64 * 1024 || System.currentTimeMillis() < clipboardCooldown) {
+      if (value.length.toLong > maxClipboardLength || System.currentTimeMillis() < clipboardCooldown) {
         val player = Minecraft.getMinecraft.thePlayer
         val handler = Minecraft.getMinecraft.getSoundHandler
         handler.playSound(new PositionedSoundRecord(new ResourceLocation("note.harp"), 1, 1, player.posX.toFloat, player.posY.toFloat, player.posZ.toFloat))

--- a/src/main/scala/li/cil/oc/server/component/Keyboard.scala
+++ b/src/main/scala/li/cil/oc/server/component/Keyboard.scala
@@ -89,17 +89,46 @@ class Keyboard(val host: EnvironmentHost) extends prefab.ManagedEnvironment with
         }
       case Array(p: EntityPlayer, value: String) if message.name == "keyboard.clipboard" =>
         if (isUseableByPlayer(p)) {
-          for (line <- value.linesWithSeparators) {
+          // linesWithSeparators is used here deliberately: unlike lines it
+          // retains the newline characters. The helper then fills parts by
+          // character capacity, crossing line boundaries when possible and
+          // splitting individual long lines when necessary.
+          for (part <- clipboardParts(value)) {
             if (Settings.get.inputUsername) {
-              signal(p, "clipboard", line, p.getCommandSenderName)
+              signal(p, "clipboard", part, p.getCommandSenderName)
             }
             else {
-              signal(p, "clipboard", line)
+              signal(p, "clipboard", part)
             }
           }
         }
       case _ =>
     }
+  }
+
+  private def clipboardParts(value: String): Iterator[String] = {
+    val limit = Settings.get.maxClipboard max 1
+    val parts = mutable.ArrayBuffer.empty[String]
+    val current = new mutable.StringBuilder
+
+    for (line <- value.linesWithSeparators) {
+      var offset = 0
+      while (offset < line.length) {
+        val count = math.min(limit - current.length, line.length - offset)
+        current.append(line.substring(offset, offset + count))
+        offset += count
+
+        if (current.length == limit) {
+          parts += current.toString()
+          current.clear()
+        }
+      }
+    }
+
+    if (current.nonEmpty) {
+      parts += current.toString()
+    }
+    parts.iterator
   }
 
   // ----------------------------------------------------------------------- //

--- a/src/main/scala/li/cil/oc/server/machine/Machine.scala
+++ b/src/main/scala/li/cil/oc/server/machine/Machine.scala
@@ -102,6 +102,11 @@ class Machine(val host: MachineHost) extends prefab.ManagedEnvironment with mach
 
   private var cost = Settings.get.computerCost * Settings.get.tickFrequency
 
+  // A clipboard event is input transport, not a computer operation. Keep
+  // track of it so the tick that only moves clipboard data through the
+  // machine does not drain the machine's energy buffer.
+  @volatile private var processingClipboardSignal = false
+
   private val maxSignalQueueSize = Settings.get.maxSignalQueueSize
 
   // ----------------------------------------------------------------------- //
@@ -363,7 +368,14 @@ class Machine(val host: MachineHost) extends prefab.ManagedEnvironment with mach
     true
   }
 
-  override def popSignal(): Machine.Signal = signals.synchronized(if (signals.isEmpty) null else signals.dequeue().convert())
+  override def popSignal(): Machine.Signal = signals.synchronized {
+    val signal = if (signals.isEmpty) null else signals.dequeue()
+    // popSignal is called when Lua has finished the previous event and asks
+    // for the next one. Keep this flag set across direct-call budget yields
+    // and synchronized callbacks until that happens.
+    processingClipboardSignal = signal != null && signal.name == "clipboard"
+    if (signal == null) null else signal.convert()
+  }
 
   override def methods(value: scala.AnyRef) = Callbacks(value).map(entry => {
     val (name, callback) = entry
@@ -526,6 +538,9 @@ class Machine(val host: MachineHost) extends prefab.ManagedEnvironment with mach
              Machine.State.Restarting |
              Machine.State.Stopping |
              Machine.State.Stopped => // No power consumption.
+        case _ if isClipboardPowerFree =>
+          // Clipboard transport itself is free. The Lua code and any screen
+          // rendering it performs still use their normal component costs.
         case Machine.State.Sleeping if remainIdle > 0 && signals.isEmpty =>
           if (!node.tryChangeBuffer(-cost * Settings.get.sleepCostFactor)) {
             crash("gui.Error.NoEnergy")
@@ -638,6 +653,16 @@ class Machine(val host: MachineHost) extends prefab.ManagedEnvironment with mach
         if (message.name == "computer.start" && !isPaused) start()
         else if (message.name == "computer.stop") stop()
     }
+  }
+
+  /**
+   * Clipboard input is delivered as ordinary machine signals, but it should
+   * not make a sleeping machine pay a full running tick merely because input
+   * arrived. This also covers the tick after the worker has popped the
+   * signal, when the queue may already be empty.
+   */
+  private def isClipboardPowerFree: Boolean = signals.synchronized {
+    processingClipboardSignal || signals.nonEmpty && signals.forall(_.name == "clipboard")
   }
 
   override def onConnect(node: Node) {


### PR DESCRIPTION
## Motivation

Clipboard input was previously converted into **one signal per line** using `linesWithSeparators`.

Because machine signal queues are limited, files containing many short lines could be truncated even when their total size was relatively small. The `misc.maxClipboard` configuration value existed, but was **NOT** used by this signal path. Many players even attempted to condense their scripts into a single line. It's painful.

Large pastes into the OpenOS editor also trigger many GPU redraw operations, which could exhaust the computer's energy before all clipboard signals were processed. Energy usage is not necessary.

## Summary
- Wire `misc.maxClipboard` into runtime settings.
- Pack clipboard text into maximum-sized signal chunks across line boundaries while preserving line separators.
- Derive the client-side paste limit from the clipboard chunk size and machine signal queue capacity.
- Avoid charging normal computer and GPU operation energy while processing clipboard input.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
