### PR TITLE
Added ColorUtils

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.95-gtnh:dev")
     api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-999-GTNH:dev")
-    implementation("com.github.GTNewHorizons:GTNHLib:0.11.24:dev") {transitive = false}
+    implementation("com.github.GTNewHorizons:GTNHLib:0.11.43:dev") {transitive = false}
 
     compileOnly("com.github.GTNewHorizons:Angelica:2.1.52:api") {transitive = false}
     compileOnly("com.github.GTNewHorizons:Avaritiaddons:1.9.4-GTNH:dev") {transitive = false}

--- a/src/main/java/li/cil/oc/util/ColorUtils.java
+++ b/src/main/java/li/cil/oc/util/ColorUtils.java
@@ -1,0 +1,14 @@
+package li.cil.oc.util;
+
+import com.gtnewhorizon.gtnhlib.color.ColorResource;
+
+public class ColorUtils {
+
+  private static final ColorResource.Factory color = new ColorResource.Factory("opencomputers");
+
+  public static final ColorResource
+  // spotless:off
+      neiDocTitle  = color.rgb("neiDocTitle", "0x000000"),
+      neiDocText   = color.rgb("neiDocText",  "0x333333");
+  // spotless:on
+}

--- a/src/main/scala/li/cil/oc/integration/nei/CallbackDocHandler.scala
+++ b/src/main/scala/li/cil/oc/integration/nei/CallbackDocHandler.scala
@@ -8,7 +8,6 @@ import li.cil.oc.api.prefab
 import li.cil.oc.server.driver.Registry
 import li.cil.oc.server.machine.Callbacks
 import net.minecraft.item.ItemStack
-import net.minecraft.util.EnumChatFormatting
 
 import scala.collection.convert.WrapAsScala._
 
@@ -66,8 +65,7 @@ class CallbackDocHandler(pages: Option[Array[String]]) extends PagedUsageHandler
             case VexPattern(head, tail) => (name + head, tail)
             case _ => (name, doc)
           }
-          wrap(signature, 160).map(EnumChatFormatting.BLACK.toString + _).mkString("\n") +
-            EnumChatFormatting.RESET + "\n" +
+          wrap(signature, 160).mkString("\n") + "\n" +
             wrap(documentation, 152).map("  " + _).mkString("\n")
         }
     }

--- a/src/main/scala/li/cil/oc/integration/nei/PagedUsageHandler.scala
+++ b/src/main/scala/li/cil/oc/integration/nei/PagedUsageHandler.scala
@@ -6,6 +6,7 @@ import codechicken.lib.gui.GuiDraw
 import codechicken.nei.PositionedStack
 import codechicken.nei.recipe.GuiRecipe
 import codechicken.nei.recipe.IUsageHandler
+import li.cil.oc.util.ColorUtils
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.inventory.Container
 import net.minecraft.item.ItemStack
@@ -21,7 +22,8 @@ abstract class PagedUsageHandler(val pages: Option[Array[String]]) extends IUsag
     pages match {
       case Some(data) =>
         for ((text, line) <- data(recipe).lines.zipWithIndex) {
-          GuiDraw.drawString(text, 4, 4 + line * 10, 0x333333, false)
+          val color = if (text.startsWith("  ")) ColorUtils.neiDocText.getColor() else ColorUtils.neiDocTitle.getColor()
+          GuiDraw.drawString(text, 4, 4 + line * 10, color, false)
         }
       case _ =>
     }


### PR DESCRIPTION
## Summary
- Bumped GTNHLib
- Added ColorUtils (ColorResource - gtnhlib) + two NEI text colors
It's strange, but it works, it pretty much looks for two-space indent text, then colors accordingly (left default as black + gray (technically it was reset, which in fallback is gray)

Example:
<img width="547" height="710" alt="r" src="https://github.com/user-attachments/assets/3930eb10-8fec-4209-a236-8ae59938750f" />

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
