### PR TITLE
Don't tick afk on utility/broken packets

### DIFF
--- a/src/main/scala/li/cil/oc/common/PacketHandler.scala
+++ b/src/main/scala/li/cil/oc/common/PacketHandler.scala
@@ -30,7 +30,20 @@ abstract class PacketHandler {
     try {
       stream = new ByteBufInputStream(data)
       if (stream.read() != 0) stream = new InflaterInputStream(stream)
-      dispatch(new PacketParser(stream, player))
+      val packetParser = new PacketParser(stream, player)
+      dispatch(packetParser)
+
+      // Avoid AFK kicks by marking players as non-idle when they send packets.
+      // This will usually be stuff like typing while in screen GUIs.
+      player match {
+        case mp: EntityPlayerMP => {
+          packetParser.packetType match {
+            case PacketType.TextBufferInit => // This packet isn't a player interaction result, don't tick the afk timer
+            case _ => mp.func_143004_u()
+          }
+        }
+        case _ => // Uh... OK?
+      }
     } catch {
       case e: Throwable =>
         OpenComputers.log.warn("Received a badly formatted packet.", e)
@@ -42,13 +55,6 @@ abstract class PacketHandler {
       if (data != null && data.refCnt() > 0) {
         data.release();
       }
-    }
-
-    // Avoid AFK kicks by marking players as non-idle when they send packets.
-    // This will usually be stuff like typing while in screen GUIs.
-    player match {
-      case mp: EntityPlayerMP => mp.func_143004_u()
-      case _ => // Uh... OK?
     }
   }
 

--- a/src/main/scala/li/cil/oc/common/PacketHandler.scala
+++ b/src/main/scala/li/cil/oc/common/PacketHandler.scala
@@ -38,7 +38,7 @@ abstract class PacketHandler {
       player match {
         case mp: EntityPlayerMP => {
           packetParser.packetType match {
-            case PacketType.TextBufferInit => // This packet isn't a player interaction result, don't tick the afk timer
+            case PacketType.TextBufferInit | PacketType.RobotStateRequest => // This packet isn't a player interaction result, don't tick the afk timer
             case _ => mp.func_143004_u()
           }
         }


### PR DESCRIPTION
## Summary
This PR stops ticking the afk timer on utility or broken client packets that opencomputers' server recieves.

### Some more context
In my playthrough (GTNH 2.8.4), building an oc computer just breaks the afk detection in like 4-5 chunk radius, I narrowed it down to `TextBufferInit` packet from opencomputers mod, which does not seem to be a result of any player interaction and is sent very frequently for seemingly no reason. Not sure what's the real underlying issue on why it is being sent so much, nor have I dug deep enough to understand the use of it, but it 100% should not tick the afk timer.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
