### PR TITLE
Adjust the BEC Maxwell Gate API to align with its improvements.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.11.31:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.7.10:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:Galacticraft:3.4.31-GTNH:dev") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.23:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.124:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:ModularUI:1.3.4:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:ModularUI2:2.3.80-1.7.10:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.8.111-GTNH:dev") {transitive = false}

--- a/src/main/scala/li/cil/oc/integration/gregtech/DriverBECDiode.java
+++ b/src/main/scala/li/cil/oc/integration/gregtech/DriverBECDiode.java
@@ -58,25 +58,35 @@ public final class DriverBECDiode extends DriverSidedTileEntity {
       return 10;
     }
 
-    @Callback(doc = "function():string -- Returns the name of the fluid used as condensate filter, or nil if no filter is set.")
-    public Object[] getCondensateFilter(Context context, Arguments args) {
-      Fluid filter = tileEntity.getCondensateFilter();
+    @Callback(doc = "function(slot:number):string -- Returns the name of the fluid used as condensate filter in the given slot, or nil if no filter is set.")
+    public Object[] getCondensateFilterAt(Context context, Arguments args) {
+      int slot = getFilterSlot(args.checkInteger(0));
+      Fluid filter = tileEntity.getCondensateFilterAt(slot);
       return new Object[] { filter == null ? null : FluidRegistry.getFluidName(filter) };
     }
 
-    @Callback(doc = "function(fluidName:string) -- Sets the condensate filter to the given fluid name.")
-    public Object[] setCondensateFilter(Context context, Arguments args) {
-      String name = args.optString(0, null);
+    @Callback(doc = "function(slot:number[, fluidName:string]) -- Sets the condensate filter in the given slot to the given fluid name, or clears it if nil.")
+    public Object[] setCondensateFilterAt(Context context, Arguments args) {
+      int slot = getFilterSlot(args.checkInteger(0));
+      String name = args.optString(1, null);
       if (name == null) {
-        tileEntity.setCondensateFilter(null);
+        tileEntity.setCondensateFilterAt(slot, null);
         return null;
       }
       Fluid fluid = FluidRegistry.getFluid(name);
       if (fluid == null) {
         throw new IllegalArgumentException("Unknown fluid: " + name);
       }
-      tileEntity.setCondensateFilter(fluid);
+      tileEntity.setCondensateFilterAt(slot, fluid);
       return null;
+    }
+
+    private int getFilterSlot(int luaSlot) {
+      int filterCount = tileEntity.getCondensateFilterCount();
+      if (luaSlot < 1 || luaSlot > filterCount) {
+        throw new IllegalArgumentException("Filter slot must be between 1 and " + filterCount);
+      }
+      return luaSlot - 1;
     }
   }
 }

--- a/src/main/scala/li/cil/oc/integration/gregtech/DriverBECDiode.java
+++ b/src/main/scala/li/cil/oc/integration/gregtech/DriverBECDiode.java
@@ -17,6 +17,11 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import li.cil.oc.integration.ManagedTileEntityEnvironment;
 import tectech.thing.metaTileEntity.multi.bec.MTEBECDiode;
 
@@ -56,6 +61,48 @@ public final class DriverBECDiode extends DriverSidedTileEntity {
     @Override
     public int priority() {
       return 10;
+    }
+
+    @Callback(doc = "function():number -- Returns the number of condensate filter slots.")
+    public Object[] getCondensateFilterCount(Context context, Arguments args) {
+      return new Object[] { tileEntity.getCondensateFilterCount() };
+    }
+
+    @Callback(doc = "function():table -- Returns the condensate filters by slot, using nil for empty slots.")
+    public Object[] getCondensateFilters(Context context, Arguments args) {
+      Map<Integer, String> filters = new HashMap<>();
+      List<Fluid> values = tileEntity.getCondensateFilters();
+      for (int i = 0; i < values.size(); i++) {
+        Fluid fluid = values.get(i);
+        filters.put(i + 1, fluid == null ? null : FluidRegistry.getFluidName(fluid));
+      }
+      return new Object[] { filters };
+    }
+
+    @Callback(doc = "function(filters:table) -- Sets the condensate filters by slot to fluid names, or nil for empty slots.")
+    public Object[] setCondensateFilters(Context context, Arguments args) {
+      Map filters = args.checkTable(0);
+      int filterCount = tileEntity.getCondensateFilterCount();
+      List<Fluid> values = new ArrayList<>(filterCount);
+
+      for (int i = 1; i <= filterCount; i++) {
+        Object value = filters.get(i);
+        if (value == null) {
+          values.add(null);
+          continue;
+        }
+        if (!(value instanceof String)) {
+          throw new IllegalArgumentException("Filter " + i + " must be a fluid name or nil");
+        }
+        Fluid fluid = FluidRegistry.getFluid((String) value);
+        if (fluid == null) {
+          throw new IllegalArgumentException("Unknown fluid: " + value);
+        }
+        values.add(fluid);
+      }
+
+      tileEntity.setCondensateFilters(values);
+      return null;
     }
 
     @Callback(doc = "function(slot:number):string -- Returns the name of the fluid used as condensate filter in the given slot, or nil if no filter is set.")


### PR DESCRIPTION
## Summary

In the [commit](https://github.com/GTNewHorizons/GT5-Unofficial/commit/0255a221091563ce5f326e8575ebacb5eb197ef7) on August 27 for GT5U, the Maxwell Gate was improved to have multiple filter slots. This commit introduced the `@OCMethod`-annotated interfaces `getCondensateFilterAt` and `setCondensateFilterAt`. However, the original OpenComputers driver still called the single-filter interface, making it impossible to access the other filter slots through OpenComputers.

This PR adds `getCondensateFilterAt` and `setCondensateFilterAt` to the OpenComputers callbacks. Additionally, since the original methods `getCondensateFilter` and `setCondensateFilter` are redundant with the new methods, they have been removed.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
